### PR TITLE
Simple alias field

### DIFF
--- a/src/transformers/aws-to-config.js
+++ b/src/transformers/aws-to-config.js
@@ -73,8 +73,14 @@ module.exports = function(aws) {
             assign(awsRecord, "Region", record, "region");
 
             // Alias
-            assign(awsRecord, "AliasTarget.DNSName", record, "alias.dns", fqdn.remove);
-            assign(awsRecord, "AliasTarget.EvaluateTargetHealth", record, "alias.health");
+            if(awsRecord.AliasTarget) {
+                if(obj.get(awsRecord, "AliasTarget.EvaluateTargetHealth")) {
+                    assign(awsRecord, "AliasTarget.DNSName", record, "alias.dns", fqdn.remove);
+                    assign(awsRecord, "AliasTarget.EvaluateTargetHealth", record, "alias.health");
+                } else {
+                    record.alias = awsRecord.AliasTarget.DNSName;
+                }
+            }
 
             // GeoLoc
             assign(awsRecord, "GeoLocation.ContinentCode", record, "location.continent");

--- a/src/transformers/config-to-aws.js
+++ b/src/transformers/config-to-aws.js
@@ -63,7 +63,8 @@ module.exports = function(config, zones) {
                     change = {
                         Action : "UPSERT",
                         ResourceRecordSet : record
-                    };
+                    },
+                    alias;
                 
                 record.Name = domain;
                 record.Type = config.type;
@@ -96,10 +97,12 @@ module.exports = function(config, zones) {
                 
                 // Alias (exits early, since it has no resource records to iterate)
                 if(config.alias) {
+                    alias = typeof config.alias === "string" ? { dns : config.alias } : config.alias;
+                    
                     record.AliasTarget = {
-                        DNSName : config.alias.dns,
-                        HostedZoneId : findZone(zones, config.alias.dns).Id.replace("/hostedzone/", ""),
-                        EvaluateTargetHealth : !!config.alias.health
+                        DNSName : alias.dns,
+                        HostedZoneId : findZone(zones, alias.dns).Id.replace("/hostedzone/", ""),
+                        EvaluateTargetHealth : !!alias.health
                     };
                     
                     return params.ChangeBatch.Changes.push(change);

--- a/src/validators/config/record.js
+++ b/src/validators/config/record.js
@@ -12,11 +12,14 @@ module.exports = joi.object().keys({
     ],
     
     // Alias record
-    alias : joi.object().keys({
-        id     : lib.str,
-        dns    : lib.str,
-        health : joi.boolean()
-    }),
+    alias : joi.alternatives().try(
+        joi.object().keys({
+            id     : lib.str,
+            dns    : lib.str,
+            health : joi.boolean()
+        }),
+        lib.str
+    ),
     
     // TTL cannot be set for Alias records
     ttl : lib.ttl

--- a/test/transformers_aws-to-config.js
+++ b/test/transformers_aws-to-config.js
@@ -1,0 +1,232 @@
+"use strict";
+
+var assert    = require("assert"),
+    transform = require("../src/transformers/aws-to-config.js");
+    
+describe("transformers", function() {
+    describe("AWS to Config", function() {
+        it("should create top-level zones", function() {
+            var out = transform([{
+                    Name : "fooga.com.",
+                    Records : []
+                }]);
+
+            assert.deepEqual(out, {
+                zones : {
+                    "fooga.com" : {
+                        records : {}
+                    }
+                }
+            });
+        });
+
+        it("should create multiple top-level zones", function() {
+            var out = transform([{
+                    Name : "fooga.com.",
+                    Records : []
+                }, {
+                    Name : "wooga.com.",
+                    Records : []
+                }]);
+
+            assert.deepEqual(out, {
+                zones : {
+                    "fooga.com" : {
+                        records : {}
+                    },
+                    "wooga.com" : {
+                        records : {}
+                    }
+                }
+            });
+        });
+
+        it("should convert simple records", function() {
+            var out = transform([{
+                    Name : "fooga.com.",
+                    Records : [{
+                        Name : "fooga.com.",
+                        Type : "A",
+                        ResourceRecords : [{
+                            Value : "127.0.0.1"
+                        }]
+                    }]
+                }]);
+
+            assert.deepEqual(out, {
+                zones : {
+                    "fooga.com" : {
+                        records : {
+                            "fooga.com" : {
+                                type : "A",
+                                records : "127.0.0.1"
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        it("should convert simple records with multiple IPs", function() {
+            var out = transform([{
+                    Name : "fooga.com.",
+                    Records : [{
+                        Name : "fooga.com.",
+                        Type : "A",
+                        ResourceRecords : [{
+                            Value : "127.0.0.1"
+                        }, {
+                            Value : "127.0.0.2"
+                        }]
+                    }]
+                }]);
+
+            assert.deepEqual(out, {
+                zones : {
+                    "fooga.com" : {
+                        records : {
+                            "fooga.com" : {
+                                type : "A",
+                                records : [
+                                    "127.0.0.1",
+                                    "127.0.0.2"
+                                ]
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        it("should coalesce records sharing the same FQDN", function() {
+            var out = transform([{
+                    Name : "fooga.com.",
+                    Records : [{
+                        Name : "fooga.com.",
+                        Type : "A",
+                        ResourceRecords : [{
+                            Value : "127.0.0.1"
+                        }]
+                    }, {
+                        Name : "fooga.com.",
+                        Type : "A",
+                        ResourceRecords : [{
+                            Value : "127.0.0.1"
+                        }]
+                    }, {
+                        Name : "fooga.com.",
+                        Type : "A",
+                        ResourceRecords : [{
+                            Value : "127.0.0.1"
+                        }]
+                    }]
+                }]);
+
+            assert.deepEqual(out, {
+                zones : {
+                    "fooga.com" : {
+                        records : {
+                            "fooga.com" : [{
+                                type : "A",
+                                records : "127.0.0.1"
+                            }, {
+                                type : "A",
+                                records : "127.0.0.1"
+                            }, {
+                                type : "A",
+                                records : "127.0.0.1"
+                            }]
+                        }
+                    }
+                }
+            });
+        });
+
+        it("should convert TTL in seconds to human durations", function() {
+            var out = transform([{
+                    Name : "fooga.com.",
+                    Records : [{
+                        Name : "fooga.com.",
+                        Type : "A",
+                        TTL : 300,
+                        ResourceRecords : [{
+                            Value : "127.0.0.1"
+                        }]
+                    }]
+                }]);
+
+            assert.deepEqual(out, {
+                zones : {
+                    "fooga.com" : {
+                        records : {
+                            "fooga.com" : {
+                                type : "A",
+                                records : "127.0.0.1",
+                                ttl : "5 minutes"
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        it("should convert AliasTarget data into a simpler form", function() {
+            var out = transform([{
+                    Name : "fooga.com.",
+                    Records : [{
+                        Name : "fooga.com.",
+                        Type : "A",
+                        AliasTarget : {
+                            DNSName : "fooga.com",
+                            EvaluateTargetHealth : false
+                        },
+                        ResourceRecords : []
+                    }]
+                }]);
+
+            assert.deepEqual(out, {
+                zones : {
+                    "fooga.com" : {
+                        records : {
+                            "fooga.com" : {
+                                type : "A",
+                                alias : "fooga.com"
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        it("should convert AliasTarget data with a health check", function() {
+            var out = transform([{
+                    Name : "fooga.com.",
+                    Records : [{
+                        Name : "fooga.com.",
+                        Type : "A",
+                        AliasTarget : {
+                            DNSName : "fooga.com",
+                            EvaluateTargetHealth : true
+                        },
+                        ResourceRecords : []
+                    }]
+                }]);
+
+            assert.deepEqual(out, {
+                zones : {
+                    "fooga.com" : {
+                        records : {
+                            "fooga.com" : {
+                                type : "A",
+                                alias : {
+                                    dns : "fooga.com",
+                                    health : true
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
Allows aliases that don't have a health check or anything weird to look like this:

``` javascript
{
    type : "A",
    alias : "fooga.com"
}
```

instead of 

``` javascript
{
    type : "A",
    alias : {
        dns : "fooga.com"
    }
}
```

which is a little cleaner and simpler to type.

Also snuck in some tests for `aws-to-config` transforms because that needed to happen.
